### PR TITLE
Fixes changes on b14

### DIFF
--- a/casino/casino.py
+++ b/casino/casino.py
@@ -16,7 +16,7 @@ from .deck import Deck
 from .checks import Checks
 
 # Red
-from redbot.core.i18n import CogI18n
+from redbot.core.i18n import cog_il8n, Translator
 from redbot.core import Config, bank
 
 # Discord
@@ -30,7 +30,7 @@ __version__ = "2.0.15"
 __author__ = "Redjumpman"
 
 log = logging.getLogger("red.casino")
-_ = CogI18n("Casino", __file__)
+_ = Translator("Casino", __file__)
 
 deck = Deck()
 


### PR DESCRIPTION
Changes on redbot made the casino plugin unable to run. After these changes it's able to be loaded fine.

This does break backwards compatibility with anyone not using latest v3 build though.  