### PR TITLE
[V3 Pokedex] Use red's bundled data feature for CSV files

### DIFF
--- a/pokedex/__init__.py
+++ b/pokedex/__init__.py
@@ -1,5 +1,8 @@
+from redbot.core import data_manager
 from .pokedex import Pokedex
 
 
 def setup(bot):
-    bot.add_cog(Pokedex())
+    cog = Pokedex()
+    data_manager.load_bundled_data(cog, __file__)
+    bot.add_cog(cog)

--- a/pokedex/pokedex.py
+++ b/pokedex/pokedex.py
@@ -12,14 +12,14 @@ import discord
 
 # Redbot
 from redbot.core import commands
-from redbot.core.data_manager import cog_data_path
+from redbot.core.data_manager import bundled_data_path
 from redbot.core.utils.menus import menu, DEFAULT_CONTROLS
 from redbot.core.utils.chat_formatting import box
 
 # Third-Party Requirements
 from tabulate import tabulate
 
-__version__ = "3.0.05"
+__version__ = "3.0.06"
 __author__ = "Redjumpman"
 
 switcher = {"1": "I", "2": "II", "3": "III", "4": "IV", "5": "V", "6": "VI", "7": "VII"}
@@ -249,12 +249,10 @@ class Pokedex:
             else:
                 return '', ''
 
-    @staticmethod
-    def item_search(name):
-        data_path = cog_data_path()
-        fp = os.path.join(data_path, 'CogManager', 'cogs', 'pokedex', 'data', 'Items.csv')
+    def item_search(self, name):
+        fp = bundled_data_path(self) / 'Items.csv'
         try:
-            with open(fp, 'rt', encoding='iso-8859-15') as f:
+            with fp.open('rt', encoding='iso-8859-15') as f:
                 reader = csv.DictReader(f, delimiter=',')
                 for row in reader:
                     if row['Item'] == name:
@@ -264,12 +262,10 @@ class Pokedex:
             print("The csv file could not be found in pokedex data folder.")
             return None
 
-    @staticmethod
-    def build_data(file_name, name):
-        data_path = cog_data_path()
-        fp = os.path.join(data_path, 'CogManager', 'cogs', 'pokedex', 'data', file_name)
+    def build_data(self, file_name, name):
+        fp = bundled_data_path(self) / file_name
         try:
-            with open(fp, 'rt', encoding='iso-8859-15') as f:
+            with fp.open('rt', encoding='iso-8859-15') as f:
                 reader = csv.DictReader(f, delimiter=',')
                 for row in reader:
                     if row['Pokemon'] == name:


### PR DESCRIPTION
Resolves #124.

### Changes
[FIXED] CSV files not being found if the cog install path is not the default (#124).
[CHANGED] The CSV files will now be loaded as bundled data and thus will be copied to Red's data directory

### Details
Calling `data_manager.load_bundled_data(cog, __file__)` in `setup()` tells the data manager to copy the files in `pokedex/data` to `/path/to/cog/data/path/Pokedex/bundled_data`. Then, calling `data_manager.bundled_data_path(cog_instance)` will return the latter aforementioned path. As this resolves #124, it is better than trying to guess where the data is located based on where the cog is installed.