### PR TITLE
[CHANGED] Russian roulette messages

### DIFF
--- a/russianroulette/russianroulette.py
+++ b/russianroulette/russianroulette.py
@@ -10,7 +10,7 @@ from .kill import outputs
 from redbot.core import Config, bank, commands
 
 
-__version__ = "3.0.02"
+__version__ = "3.0.03"
 __author__ = "Redjumpman"
 
 

--- a/russianroulette/russianroulette.py
+++ b/russianroulette/russianroulette.py
@@ -129,9 +129,9 @@ class RussianRoulette:
         chamber = await self.db.guild(ctx.guild).Chamber_Size()
 
         if len(self.players) == 1:
-            await ctx.send("{0.author.mention} is gathering players for a game of russian "
-                           "roulette!\nType `{0.prefix}russian` to enter.".format(ctx))
             wait = await self.db.guild(ctx.guild).Wait_Time()
+            await ctx.send("{0.author.mention} is gathering players for a game of russian "
+                           "roulette!\nType `{0.prefix}russian` to enter. The round will start in {1} seconds.".format(ctx, wait))
             await asyncio.sleep(wait)
             await self.start_game(ctx)
         else:


### PR DESCRIPTION
Russian roulette now shows the wait time in the start message. Before users might think the bot wasn't starting the game, now its clear. Improvements could be made so that it converts to MM:SS format instead of just showing the seconds, but I think its fine. Feel free to edit if you want to add that capability.

example https://i.imgur.com/Ki178NY.png

-----

tested on:

```
Python version: 3.6.5 (default, Aug  1 2018, 06:22:21) 
[GCC 6.3.0 20170516]
Red version: 3.0.0b18
OS version: Raspbian GNU/Linux 9
System arch: armv7l
User: pi
```


:) (love the games btw)